### PR TITLE
fix: 防止meme重复执行命令

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ class PokeproPlugin(Star):
         obj_msg = event.message_obj.message
         obj_msg.clear()
         obj_msg.extend([At(qq=event.get_self_id()), Plain(command)])
-        event.message_obj.message_str = command
+        # event.message_obj.message_str = command
         event.message_str = command
         self.context.get_event_queue().put_nowait(event)
         event.should_call_llm(True)


### PR DESCRIPTION
Preventing meme plugin from repeating a command

## Sourcery 总结

错误修复：
- 禁用冗余的 message_obj.message_str 赋值，以避免重复的命令执行

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Disable redundant message_obj.message_str assignment to avoid duplicate command execution

</details>