### PR TITLE
feat: 限制戳的次数，优化配置映射

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,7 +14,7 @@
     "poke_max_times": {
         "description": "戳一戳最大次数",
         "type": "int",
-        "hint": "发送戳一戳时的最大连戳数",
+        "hint": "发送戳一戳时的最大连戳数, 但bot管理员不受限制",
         "default": 5
     },
     "poke_interval": {
@@ -47,7 +47,7 @@
         "hint": "触发禁言时，如果禁言失败，使用的llm提示模板",
         "default": "{username} 戳了你一下，你因为你的身份比这人低而无法禁言这人，请你用一句话吐槽一下，确保符合人设的同时夹带生气甚至愤怒的情绪的情绪，考虑上下文，确保通顺不突兀"
     },
-    "ban_time_range_str": {
+    "ban_time": {
         "description": "随机禁言时间范围",
         "type": "string",
         "hint": "触发禁言时随机禁言的时间范围，单位为秒，用波浪线分隔，例如：30~300",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_pokepro # 这是你的插件的唯一识别名。
 desc: 【更专业的戳一戳插件】支持触发（反戳：LLM：face：图库：禁言：meme：api：开盒），戳@某人，跟戳 # 插件简短描述
 help:   # 插件的帮助信息
-version: v1.0.9 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.1.0 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_pokepro # 插件的仓库地址


### PR DESCRIPTION
## Sourcery 总结

通过切换到直接字典访问来优化配置映射，简化 poke 和 ban 逻辑，强制执行 poke 限制，并更新到 1.1.0 版本。

新特性：
- 强制执行每个请求的 poke 计数限制，具有动态解析和管理员级别的覆盖

改进：
- 将配置存储重命名为 `self.conf`，并将所有设置切换为直接字典访问
- 简化基于列表的配置值的检索，并移除已弃用的属性
- 重构 poke 处理，以统一群组成员和消息历史查找，并使用单一的休眠间隔源
- 将 ban 时间范围模式替换为单个 `ban_time` 配置，并相应地更新 ban 处理
- 将插件版本提升至 1.1.0

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize configuration mapping by switching to direct dictionary access, simplify poke and ban logic, enforce poke limits, and update to version 1.1.0.

New Features:
- Enforce a per-request poke count limit with dynamic parsing and admin-level overrides

Enhancements:
- Rename config storage to `self.conf` and switch all settings to direct dictionary access
- Streamline retrieval of list-based config values and remove deprecated attributes
- Refactor poke handling to unify group member and message history lookups and use a single sleep interval source
- Replace ban time range schema with a single `ban_time` config and update ban handling accordingly
- Bump plugin version to 1.1.0

</details>