### PR TITLE
fix: 修复无法获取人设 prompt 导致的无法调用LLM回复bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -158,7 +158,7 @@ class PokeproPlugin(Star):
 
             llm_response = await using_provider.text_chat(
                 prompt=format_prompt,
-                system_prompt=persona_prompt,
+                system_prompt=system_prompt,
                 contexts=contexts,
             )
             return llm_response.completion_text


### PR DESCRIPTION
- 在高版本中，Provider 的 curr_personality 属性已被移除，无法再通过 using_provider.curr_personality 获取 personality，导致无法调用LLM回复
- 通过 conversation.persona_id 和 persona_manager.get_default_persona_v3 来获取 persona_id，再通过 persona_id 获取相应的 persona，进而获取 system_prompt

## Sourcery 总结

错误修复：
- 恢复用于 LLM 回复的 system_prompt 检索，通过使用 `conversation.persona_id` 和 `persona_manager` 而不是已移除的 `provider.curr_personality`，并回退到默认角色

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore system_prompt retrieval for LLM replies by using conversation.persona_id and persona_manager instead of the removed provider.curr_personality, with a fallback to the default persona

</details>