### PR TITLE
fix:Improve group_id assignment logic

### DIFF
--- a/core/send_poke.py
+++ b/core/send_poke.py
@@ -75,7 +75,7 @@ class PokeSender:
 
         self_id = int(event.get_self_id())
         group_id_raw = event.get_group_id()
-        group_id = int(group_id_raw) if group_id_raw is not None else None
+        group_id = int(group_id_raw) if group_id_raw and str(group_id_raw).strip() else None
 
         target_ids = self._normalize_target_ids(
             target_id,


### PR DESCRIPTION
修复ValueError: invalid literal for int() with base 10: ''bug。增加None 和空字符串 ''检验
使用插件时发现有时会出现试图将一个空字符串 '' 转换为整数 int的错误，这里增加了一个None 和空字符串 ''检验，只有当 group_id_raw 有实际内容时才会尝试转换。

## Summary by Sourcery

Bug Fixes:
- 通过仅在 `group_id` 包含非空值时才将其转换为 `int`，防止当 `group_id` 为空字符串或仅包含空白时出现 `ValueError`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent ValueError when group_id is an empty string or whitespace by only converting it to int when it contains a non-empty value.

</details>