### PR TITLE
fix: 修复 deepcopy event 导致的 Future pickle 错误

### DIFF
--- a/core/on_poke.py
+++ b/core/on_poke.py
@@ -139,7 +139,9 @@ class GetPokeHandler:
 
     async def respond_cmd(self, event: AiocqhttpMessageEvent):
         """调用命令"""
-        evt = copy.deepcopy(event)
+        evt = copy.copy(event)  
+        evt._extras = {}         
+        evt.message_obj = copy.copy(event.message_obj) 
         event.stop_event()
 
         cmd = self.cfg.get_command()


### PR DESCRIPTION
## 修复内容
修复戳一戳响应时 `copy.deepcopy(event)` 导致的 `TypeError: cannot pickle '_asyncio.Future' object` 错误

## 问题原因
`event` 对象内部的 `_extras` 字段包含 `asyncio.Future` 等不可序列化对象，`deepcopy` 会递归复制导致异常

## 解决方案
- 将 `deepcopy` 改为 `copy`（浅拷贝）
- 清空 `_extras` 避免复制运行时对象
- 单独浅拷贝 `message_obj`（如需修改）

## 测试
- [x] 戳一戳功能正常响应
- [x] 不再抛出 pickle 异常

Fixes #33

## Summary by Sourcery

Bug Fixes:
- 通过改用浅拷贝并清除仅在运行时使用的附加字段，避免在对包含不可序列化 `asyncio.Future` 的事件执行 `deepcopy` 时引发 `TypeError`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid TypeError from deepcopying events containing non-serializable asyncio.Future by switching to shallow copies and clearing runtime-only extras.

</details>