### PR TITLE
refactor: 更改 LLM 请求方式

### DIFF
--- a/core/llm.py
+++ b/core/llm.py
@@ -1,7 +1,6 @@
 import json
 
 from astrbot.api import logger
-from astrbot.core.db.po import Persona, Personality
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
@@ -16,80 +15,24 @@ class LLMService:
         self.context = context
         self.cfg = config
 
-    async def get_respond(
-        self, event: AiocqhttpMessageEvent, prompt_template: str
-    ) -> str | None:
-        """调用 LLM 回复"""
+    async def get_conversation(self, event: AiocqhttpMessageEvent):
+        """获取或创建当前会话的 conversation 对象"""
         umo = event.unified_msg_origin
-
-        contexts = await self._get_contexts(umo)
-        if contexts is None:
-            return None
-
-        system_prompt = await self._get_system_prompt(umo)
-        if not system_prompt:
-            return None
-
-        prompt = await self._build_prompt(event, prompt_template)
-
-        using_provider = self.context.get_using_provider(umo)
-        if not using_provider:
-            return None
-
+        conv_mgr = self.context.conversation_manager
         try:
-            logger.debug(f"[戳一戳] LLM 调用：{prompt}")
-            resp = await using_provider.text_chat(
-                system_prompt=system_prompt,
-                prompt=prompt,
-                contexts=contexts,
-            )
-            return resp.completion_text
+            cid = await conv_mgr.get_curr_conversation_id(umo)
+            if not cid:
+                cid = await conv_mgr.new_conversation(umo, event.get_platform_id())
+            return await conv_mgr.get_conversation(umo, cid)
         except Exception as e:
-            logger.error(f"LLM 调用失败：{e}")
+            logger.warning(f"[Pokepro] 获取 conversation 失败: {e}")
             return None
 
-    # ========================
-    # 内部方法
-    # ========================
-
-    async def _get_contexts(self, umo) -> list | None:
-        """获取当前会话上下文"""
-        conv_mgr = self.context.conversation_manager
-        cid = await conv_mgr.get_curr_conversation_id(umo)
-        if not cid:
-            return None
-
-        conversation = await conv_mgr.get_conversation(umo, cid)
-        if not conversation:
-            return None
-
-        return json.loads(conversation.history)
-
-    async def _get_system_prompt(self, umo) -> str | None:
-        """获取 system prompt（优先会话人格，失败回退默认人格）"""
-        conv_mgr = self.context.conversation_manager
-        cid = await conv_mgr.get_curr_conversation_id(umo)
-        if not cid:
-            return None
-
-        conversation = await conv_mgr.get_conversation(umo, cid)
-        if not conversation:
-            return None
-
-        try:
-            persona: Persona = await self.context.persona_manager.get_persona(
-                persona_id=conversation.persona_id  # type: ignore
-            )
-            return persona.system_prompt
-        except ValueError:
-            personality: Personality = (
-                await self.context.persona_manager.get_default_persona_v3(umo=umo)
-            )
-            return personality["prompt"]
-
-    async def _build_prompt(self, event: AiocqhttpMessageEvent, template: str) -> str:
+    async def build_prompt(
+        self, event: AiocqhttpMessageEvent, prompt_template: str
+    ) -> str:
         """构建用户 prompt"""
         username = await get_nickname(
             event.bot, event.get_group_id(), event.get_sender_id()
         )
-        return template.format(username=username)
+        return prompt_template.format(username=username)

--- a/core/on_poke.py
+++ b/core/on_poke.py
@@ -80,6 +80,7 @@ class GetPokeHandler:
             return
 
         module = random.choices(self._modules, self._weights, k=1)[0]
+        logger.debug(f"[戳一戳] 触发响应模块: {module}")
         handler = self.handlers[module]
 
         try:
@@ -104,8 +105,9 @@ class GetPokeHandler:
     async def respond_llm(self, event: AiocqhttpMessageEvent):
         """调用llm回复"""
         template = self.cfg.llm.template
-        if text := await self.llm.get_respond(event, template):
-            yield event.plain_result(text)
+        prompt = await self.llm.build_prompt(event, template)
+        conversation = await self.llm.get_conversation(event)
+        yield event.request_llm(prompt=prompt, conversation=conversation)
 
     async def respond_face(self, event: AiocqhttpMessageEvent):
         """回复emoji(QQ表情)"""
@@ -133,8 +135,9 @@ class GetPokeHandler:
         except Exception:
             template = cfg.ban_fail_template
         finally:
-            if text := await self.llm.get_respond(event, template):
-                yield event.plain_result(text)
+            prompt = await self.llm.build_prompt(event, template)
+            conversation = await self.llm.get_conversation(event)
+            yield event.request_llm(prompt=prompt, conversation=conversation)
 
     async def respond_cmd(self, event: AiocqhttpMessageEvent):
         """调用命令"""


### PR DESCRIPTION
原本的响应还是没有被outputpro处理

## Summary by Sourcery

重构用于处理 poke 响应的 LLM 交互方式，改为使用基于会话的请求和统一的提示词构建逻辑。

新功能：
- 支持通过事件的 `request_llm` 接口，结合会话上下文来请求 LLM 响应。

缺陷修复：
- 确保与 poke 相关的 LLM 响应通过统一的输出/请求管道进行处理，而不是直接调用具体提供方。

增强改进：
- 引入一个可复用的方法，用于为事件获取或创建当前会话对象。
- 将提示词构建逻辑抽取到专用的 `build_prompt` 帮助函数中，并支持可配置模板。
- 添加调试日志，以指示触发了哪个 poke 响应模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor LLM interaction for poke responses to use conversation-based requests and shared prompt construction.

New Features:
- Support requesting LLM responses via the event's request_llm interface using conversation context.

Bug Fixes:
- Ensure poke-related LLM responses are processed through the unified output/request pipeline instead of invoking providers directly.

Enhancements:
- Introduce a reusable method to retrieve or create the current conversation object for an event.
- Extract prompt construction into a dedicated build_prompt helper using configurable templates.
- Add debug logging to indicate which poke response module is triggered.

</details>