### PR TITLE
feat: 支持工具调用戳一戳

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,13 @@ class PokeproPlugin(Star):
         self.get_poke_handler = GetPokeHandler(context, self.cfg, self.sender)
         self.scheduler = None
 
+    def _normalize_poke_times(self, times: int | str | None) -> int:
+        try:
+            value = int(times) if times is not None else 1
+        except (TypeError, ValueError):
+            value = 1
+        return max(1, min(self.cfg.poke_max_times, value))
+
     async def initialize(self):
         if self.cfg.scheduler.enabled:
             self.scheduler = PokeScheduler(self.cfg, self.sender)
@@ -34,8 +41,7 @@ class PokeproPlugin(Star):
         """戳 @某人/我/全体成员"""
         msg = event.message_str
         end = msg.split()[-1]
-        times = int(end) if end.isdigit() else 1
-        times = min(self.cfg.poke_max_times, times)
+        times = self._normalize_poke_times(end if end.isdigit() else 1)
 
         is_admin = event.is_admin()
         gid = event.get_group_id()
@@ -62,6 +68,38 @@ class PokeproPlugin(Star):
         )
         event.stop_event()
 
+    @filter.llm_tool()
+    async def llm_poke_user(
+        self,
+        event: AiocqhttpMessageEvent,
+        user_id: str,
+        times: int = 1,
+    ):
+        """
+        戳指定用户。
+        Args:
+            user_id(string): 要戳的目标用户QQ号，必定为一串数字，如(12345678)
+            times(number): 戳的次数，默认为1，实际会限制在插件配置允许的最大次数内
+        """
+        user_id = str(user_id).strip()
+        if not user_id or not user_id.isdigit():
+            return "戳一戳失败：user_id 必须是纯数字 QQ 号"
+
+        if user_id == event.get_self_id():
+            return "戳一戳失败：不能戳机器人自己"
+
+        actual_times = self._normalize_poke_times(times)
+
+        try:
+            await self.sender.event_send(
+                event,
+                target_ids=[user_id],
+                times=actual_times,
+            )
+            return f"已戳用户 {user_id} {actual_times} 次"
+        except Exception as e:
+            return f"戳一戳失败：{e}"
+
     @filter.platform_adapter_type(filter.PlatformAdapterType.AIOCQHTTP)
     @filter.event_message_type(filter.EventMessageType.ALL)
     async def on_message(self, event: AiocqhttpMessageEvent):
@@ -83,6 +121,3 @@ class PokeproPlugin(Star):
                     target_ids=[event.get_sender_id()],
                     times=1,
                 )
-
-
-


### PR DESCRIPTION
## Summary by Sourcery

为 LLM 新增在特定用户上触发 QQ 戳一戳动作的支持，并将戳一戳次数归一化逻辑集中管理。

New Features:
- 暴露 `llm_poke_user` 工具方法，使语言模型可以对指定的 QQ 用户发起戳一戳操作，并支持配置次数。

Enhancements:
- 将戳一戳次数的处理重构为共享的归一化辅助函数，以强制执行基于配置的次数限制并提升输入的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add LLM-exposed support for triggering QQ poke actions on specific users and centralize poke count normalization logic.

New Features:
- Expose an llm_poke_user tool method to let the language model initiate poke actions on a specified QQ user with a configurable count.

Enhancements:
- Refactor poke count handling into a shared normalization helper that enforces configuration-based limits and input robustness.

</details>