### PR TITLE
使用戳人者头像而非 bot 自身头像

### DIFF
--- a/core/on_poke.py
+++ b/core/on_poke.py
@@ -163,7 +163,7 @@ class GetPokeHandler:
 
         cmd = self.cfg.get_command()
 
-        evt.message_obj.message = [At(qq=evt.get_self_id()), Plain(cmd)]
+        evt.message_obj.message = [At(qq=evt.get_sender_id()), Plain(cmd)]
         evt.message_obj.message_str = cmd
 
         evt.is_at_or_wake_command = True


### PR DESCRIPTION
mememaker_api 等插件在制作表情包时使用 bot 头像而非戳人者头像。

将 At(qq=evt.get_self_id()) 改为 At(qq=evt.get_sender_id())

## Summary by Sourcery

Bug Fixes:
- 修复了由戳一戳触发的命令使用机器人头像/提及而不是发起者头像/提及的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix poke-triggered commands using the bot avatar/mention instead of the initiator's avatar/mention.

</details>